### PR TITLE
token jwt authentication issue

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,22 @@ engine = create_async_engine(TEST_DATABASE_URL, echo=settings.debug)
 AsyncTestingSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 AsyncSessionScoped = scoped_session(AsyncTestingSessionLocal)
 
+@pytest.fixture
+def async_client():
+    client = TestClient(app)
+    return client
+
+@pytest.fixture
+def user_token():
+    return create_access_token(data={"sub": "john_doe", "role": UserRole.AUTHENTICATED.value})
+
+@pytest.fixture
+def admin_token():
+    return create_access_token(data={"sub": "admin", "role": UserRole.ADMIN.value})
+
+@pytest.fixture
+def manager_token():
+    return create_access_token(data={"sub": "manager", "role": UserRole.MANAGER.value})
 
 @pytest.fixture
 def email_service():
@@ -217,6 +233,7 @@ def user_base_data():
     return {
         "username": "john_doe_123",
         "email": "john.doe@example.com",
+        "nickname": "Joh",
         "full_name": "John Doe",
         "bio": "I am a software engineer with over 5 years of experience.",
         "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg"
@@ -241,6 +258,7 @@ def user_create_data(user_base_data):
 def user_update_data():
     return {
         "email": "john.doe.new@example.com",
+        "first_name": "John",
         "full_name": "John H. Doe",
         "bio": "I specialize in backend development with Python and Node.js.",
         "profile_picture_url": "https://example.com/profile_pictures/john_doe_updated.jpg"
@@ -249,7 +267,7 @@ def user_update_data():
 @pytest.fixture
 def user_response_data():
     return {
-        "id": "unique-id-string",
+        "id": uuid4(),
         "username": "testuser",
         "email": "test@example.com",
         "last_login_at": datetime.now(),
@@ -260,4 +278,4 @@ def user_response_data():
 
 @pytest.fixture
 def login_request_data():
-    return {"username": "john_doe_123", "password": "SecurePassword123!"}
+    return {"username": "john_doe_123","email":"john.doe@eping.com", "password": "SecurePassword123!"}


### PR DESCRIPTION
The database operation tests were failing due to missing or inconsistent fixtures, specifically for user roles (e.g., authenticated users, admin, and manager). Additionally, critical data like nickname in user_base_data and comprehensive update fields in user_update_data were incomplete, causing validation errors.

